### PR TITLE
Add SIP lifecycle logging

### DIFF
--- a/telephony/sip_lifecycle.py
+++ b/telephony/sip_lifecycle.py
@@ -158,12 +158,69 @@ async def entrypoint(ctx: JobContext):
 
     def on_participant_connected_handler(participant: rtc.RemoteParticipant):
         asyncio.create_task(async_on_participant_connected(participant))
+
+    def on_participant_attributes_changed_handler(changed_attributes: dict, participant: rtc.Participant):
+        asyncio.create_task(async_on_participant_attributes_changed(changed_attributes, participant))
         
     async def async_on_participant_connected(participant: rtc.RemoteParticipant):
         logger.info(f"New participant connected: {participant.identity}")
+
+        # Check if this is a SIP participant and log call status
+        if participant.kind == rtc.ParticipantKind.PARTICIPANT_KIND_SIP:
+            logger.info(f"SIP participant connected: {participant.identity}")
+
+            # Log SIP attributes
+            if participant.attributes:
+                call_id = participant.attributes.get('sip.callID', 'Unknown')
+                call_status = participant.attributes.get('sip.callStatus', 'Unknown')
+                phone_number = participant.attributes.get('sip.phoneNumber', 'Unknown')
+                trunk_id = participant.attributes.get('sip.trunkID', 'Unknown')
+                trunk_phone = participant.attributes.get('sip.trunkPhoneNumber', 'Unknown')
+
+                logger.info(f"SIP Call ID: {call_id}")
+                logger.info(f"SIP Call Status: {call_status}")
+                logger.info(f"SIP Phone Number: {phone_number}")
+                logger.info(f"SIP Trunk ID: {trunk_id}")
+                logger.info(f"SIP Trunk Phone Number: {trunk_phone}")
+
+                # Log specific call status information
+                if call_status == 'active':
+                    logger.info("Call is active and connected")
+                elif call_status == 'automation':
+                    logger.info("Call is connected and dialing DTMF numbers")
+                elif call_status == 'dialing':
+                    logger.info("Call is dialing and waiting to be picked up")
+                elif call_status == 'hangup':
+                    logger.info("Call has been ended by a participant")
+                elif call_status == 'ringing':
+                    logger.info("Inbound call is ringing for the caller")
+
         await agent.session.say(f"Welcome, {participant.name or participant.identity}! I can help you add a participant to this call or end the call.")
 
+    async def async_on_participant_attributes_changed(changed_attributes: dict, participant: rtc.Participant):
+        logger.info(f"Participant {participant.identity} attributes changed: {changed_attributes}")
+
+        # Check if this is a SIP participant and if call status has changed
+        if participant.kind == rtc.ParticipantKind.PARTICIPANT_KIND_SIP:
+            # Check if sip.callStatus is in the changed attributes
+            if 'sip.callStatus' in changed_attributes:
+                call_status = changed_attributes['sip.callStatus']
+                logger.info(f"SIP Call Status updated: {call_status}")
+
+                # Log specific call status information
+                if call_status == 'active':
+                    logger.info("Call is now active and connected")
+                elif call_status == 'automation':
+                    logger.info("Call is now connected and dialing DTMF numbers")
+                elif call_status == 'dialing':
+                    logger.info("Call is now dialing and waiting to be picked up")
+                elif call_status == 'hangup':
+                    logger.info("Call has been ended by a participant")
+                elif call_status == 'ringing':
+                    logger.info("Inbound call is now ringing for the caller")
+
     ctx.room.on("participant_connected", on_participant_connected_handler)
+    ctx.room.on("participant_attributes_changed", on_participant_attributes_changed_handler)
 
 if __name__ == "__main__":
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))


### PR DESCRIPTION
This is a very widely requested demo, so I figured I would add it—logging of participant attribute changes to show how to track the state of the current call, pretty much just an example for [this doc](https://docs.livekit.io/sip/sip-participant/#sip-participant-attributes)