### PR TITLE
Remove use of private method

### DIFF
--- a/pipeline-llm/llm_powered_content_filter.py
+++ b/pipeline-llm/llm_powered_content_filter.py
@@ -62,15 +62,12 @@ class SimpleAgent(Agent):
         return None
     
     async def llm_node(self, chat_ctx, tools, model_settings=None):
-        activity = self._Agent__get_activity_or_raise()
-        assert activity.llm is not None, "llm_node called but no LLM node is available"
-        
         async def process_stream():
             buffer = ""
             chunk_buffer = []
             sentence_end_chars = {'.', '!', '?'}
             
-            async with activity.llm.chat(chat_ctx=chat_ctx, tools=tools, tool_choice=None) as stream:
+            async with self.llm.chat(chat_ctx=chat_ctx, tools=tools, tool_choice=None) as stream:
                 try:
                     async for chunk in stream:
                         content = self._extract_content(chunk)

--- a/pipeline-llm/replacing_llm_output.py
+++ b/pipeline-llm/replacing_llm_output.py
@@ -31,11 +31,8 @@ class SimpleAgent(Agent):
     async def llm_node(
         self, chat_ctx, tools, model_settings=None
     ):
-        activity = self._Agent__get_activity_or_raise()
-        assert activity.llm is not None, "llm_node called but no LLM node is available"
-        
         async def process_stream():
-            async with activity.llm.chat(chat_ctx=chat_ctx, tools=tools, tool_choice=None) as stream:
+            async with self.llm.chat(chat_ctx=chat_ctx, tools=tools, tool_choice=None) as stream:
                 async for chunk in stream:
                     if chunk is None:
                         continue

--- a/pipeline-llm/simple_content_filter.py
+++ b/pipeline-llm/simple_content_filter.py
@@ -31,11 +31,8 @@ class SimpleAgent(Agent):
     async def llm_node(
         self, chat_ctx, tools, model_settings=None
     ):
-        activity = self._Agent__get_activity_or_raise()
-        assert activity.llm is not None, "llm_node called but no LLM node is available"
-        
         async def process_stream():
-            async with activity.llm.chat(chat_ctx=chat_ctx, tools=tools, tool_choice=None) as stream:
+            async with self.llm.chat(chat_ctx=chat_ctx, tools=tools, tool_choice=None) as stream:
                 async for chunk in stream:
                     if chunk is None:
                         continue


### PR DESCRIPTION
Remove the private methods that snuck into these examples. It's a holdover from a workaround that shouldn't have been here post 1.0 GA.