### PR TITLE
Removing ctx.connect as it's no longer needed after 1.1.0

### DIFF
--- a/avatars/tavus/tavus.py
+++ b/avatars/tavus/tavus.py
@@ -405,8 +405,6 @@ class AvatarAgent(Agent):
 
 async def entrypoint(ctx: JobContext):
     agent = AvatarAgent()
-    await ctx.connect()
-
     # Create a single AgentSession with userdata
     userdata = UserData(ctx=ctx)
     session = AgentSession[UserData](

--- a/basics/change_agent_instructions.py
+++ b/basics/change_agent_instructions.py
@@ -31,8 +31,6 @@ class ChangeInstructionsAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/basics/context_variables.py
+++ b/basics/context_variables.py
@@ -32,8 +32,6 @@ class ContextAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     context_variables = {
         "name": "Shayne",
         "age": 35,

--- a/basics/echo_transcriber_agent.py
+++ b/basics/echo_transcriber_agent.py
@@ -80,8 +80,6 @@ class EchoTranscriberAgent(Agent):
         return super().stt_node(audio_with_buffer(), model_settings)
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-    
     await ctx.room.local_participant.set_attributes({"lk.agent.state": "listening"})
     
     session = AgentSession()

--- a/basics/exit_message.py
+++ b/basics/exit_message.py
@@ -35,8 +35,6 @@ class GoodbyeAgent(Agent):
         await self.session.say("Goodbye!")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/basics/function_calling.py
+++ b/basics/function_calling.py
@@ -36,8 +36,6 @@ class FunctionAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/basics/interrupts_user.py
+++ b/basics/interrupts_user.py
@@ -66,8 +66,6 @@ class UninterruptableAgent(Agent):
         self.session.say("I'll interrupt you after 1 sentence.")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/basics/listen_and_respond.py
+++ b/basics/listen_and_respond.py
@@ -27,8 +27,6 @@ class SimpleAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/basics/playing_audio.py
+++ b/basics/playing_audio.py
@@ -53,8 +53,6 @@ class FunctionAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/basics/repeater.py
+++ b/basics/repeater.py
@@ -9,8 +9,6 @@ from livekit.plugins import deepgram, openai
 load_dotenv(dotenv_path=Path(__file__).parent.parent / '.env')
 
 async def entrypoint(ctx: JobContext):
-    
-    await ctx.connect()
     session = AgentSession()
     
     @session.on("user_input_transcribed")

--- a/basics/uninterruptable.py
+++ b/basics/uninterruptable.py
@@ -24,8 +24,6 @@ class UninterruptableAgent(Agent):
         self.session.generate_reply(user_input="Say something somewhat long and boring so I can test if you're interruptable.")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/complex-agents/medical_office_triage/triage.py
+++ b/complex-agents/medical_office_triage/triage.py
@@ -156,8 +156,6 @@ class BillingAgent(BaseAgent):
 
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     userdata = UserData(ctx=ctx)
     triage_agent = TriageAgent()
     support_agent = SupportAgent()

--- a/complex-agents/nova-sonic/form_agent.py
+++ b/complex-agents/nova-sonic/form_agent.py
@@ -290,8 +290,6 @@ class FormFillerAgent(Agent):
     
 
 async def entrypoint(ctx: agents.JobContext):
-    await ctx.connect()
-    
     userdata = UserData(ctx=ctx)
 
     session = AgentSession[UserData](

--- a/complex-agents/nutrition-assistant/agent.py
+++ b/complex-agents/nutrition-assistant/agent.py
@@ -466,9 +466,6 @@ async def send_initial_nutrition_update(ctx: agents.JobContext, participant_iden
 async def entrypoint(ctx: agents.JobContext):
     # Initialize database on startup
     init_database()
-    
-    await ctx.connect()
-    
     # Wait for participant
     participant = await ctx.wait_for_participant()
     print(f"Starting nutrition assistant for {participant.identity} (using fixed ID: {FIXED_PARTICIPANT_ID})")

--- a/complex-agents/personal_shopper/personal_shopper.py
+++ b/complex-agents/personal_shopper/personal_shopper.py
@@ -373,8 +373,6 @@ class ReturnsAgent(BaseAgent):
 
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     # Initialize user data with context
     userdata = UserData(ctx=ctx)
 

--- a/complex-agents/role-playing/agent.py
+++ b/complex-agents/role-playing/agent.py
@@ -17,8 +17,6 @@ load_dotenv()
 
 async def entrypoint(ctx: JobContext):
     """Main entry point for the game"""
-    await ctx.connect()
-    
     # Initialize user data
     userdata = GameUserData(ctx=ctx)
     

--- a/complex-agents/shopify-voice-shopper/shopify.py
+++ b/complex-agents/shopify-voice-shopper/shopify.py
@@ -203,8 +203,6 @@ def create_shopify_agent(shopify_mcp_url: str) -> Agent:
     return ShopifyAgent(shopify_mcp_url)
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     userdata = ShopifyUserData(ctx=ctx)
 
     session = AgentSession[ShopifyUserData](

--- a/complex-agents/teleprompter/cartesia-ink.py
+++ b/complex-agents/teleprompter/cartesia-ink.py
@@ -11,8 +11,6 @@ from livekit.plugins import cartesia
 load_dotenv(dotenv_path=Path(__file__).parent.parent / '.env')
 
 async def entrypoint(ctx: JobContext):
-    
-    await ctx.connect()
     session = AgentSession()
 
     # Register RPC method for frontend to retrieve transcript data

--- a/complex-agents/turn-taking/agent.py
+++ b/complex-agents/turn-taking/agent.py
@@ -122,8 +122,6 @@ class SimpleAgent(Agent):
         return process_stream()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     userdata = TurnTakingUserData(ctx=ctx)
 
     session = AgentSession[TurnTakingUserData](

--- a/complex-agents/vision/agent.py
+++ b/complex-agents/vision/agent.py
@@ -78,8 +78,6 @@ class VisionAgent(Agent):
         self._tasks.append(task)
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/egress/recording_agent.py
+++ b/egress/recording_agent.py
@@ -50,9 +50,6 @@ async def entrypoint(ctx: JobContext):
     )
     lkapi = api.LiveKitAPI()
     res = await lkapi.egress.start_room_composite_egress(req)
-
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/evaluating-agents/agent_evals.py
+++ b/evaluating-agents/agent_evals.py
@@ -52,8 +52,6 @@ class SimpleEvaluationAgent(Agent):
         return None, "I've graded the answer."
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/evaluating-agents/agent_to_test.py
+++ b/evaluating-agents/agent_to_test.py
@@ -24,8 +24,6 @@ class SimpleAgent(Agent):
         )
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/events/basic_event.py
+++ b/events/basic_event.py
@@ -38,8 +38,6 @@ class SimpleAgent(Agent):
         self.emitter.emit('greet', 'Bob')
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     agent = SimpleAgent()
     agent.emitter.on('greet', agent.greet)
 

--- a/events/event_emitters.py
+++ b/events/event_emitters.py
@@ -44,8 +44,6 @@ class SimpleAgent(Agent):
         )
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     agent = SimpleAgent()
     agent.emitter.on('participant_joined', agent.welcome_participant)
     agent.emitter.on('participant_left', agent.farewell_participant)

--- a/flows/declarative_flow.py
+++ b/flows/declarative_flow.py
@@ -117,7 +117,6 @@ flow = {
 }
 
 async def entrypoint(ctx: JobContext) -> None:
-    await ctx.connect()
     session = AgentSession()
     session.userdata = SurveyData()
     session.state = {"current_node": "collect_name"}

--- a/flows/multi_stage_flow.py
+++ b/flows/multi_stage_flow.py
@@ -255,7 +255,6 @@ class SummaryAgent(BaseAgent):
             logger.error(f"Error deleting room: {e}")
 
 async def entrypoint(ctx: JobContext) -> None:
-    await ctx.connect()
     session = AgentSession()
     session.userdata = SurveyData()
     await session.start(

--- a/flows/simple_flow.py
+++ b/flows/simple_flow.py
@@ -82,7 +82,6 @@ class SummaryAgent(BaseAgent):
         await self.job_context.api.room.delete_room(request)
 
 async def entrypoint(ctx: JobContext) -> None:
-    await ctx.connect()
     session = AgentSession()
     await session.start(
         agent=GreetingAgent(

--- a/hardware/pi-zero-transcriber/pi_zero_transcriber.py
+++ b/hardware/pi-zero-transcriber/pi_zero_transcriber.py
@@ -73,8 +73,6 @@ def display_transcription(text):
 
 async def entrypoint(ctx: JobContext):
     show_startup_screen()
-    
-    await ctx.connect()
     session = AgentSession()
 
     # Keep track of the current transcription

--- a/home_assistant/homeautomation.py
+++ b/home_assistant/homeautomation.py
@@ -179,8 +179,6 @@ class SimpleAgent(Agent):
         raise StopResponse()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/mcp/agent.py
+++ b/mcp/agent.py
@@ -23,8 +23,6 @@ class MyAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession(
         vad=silero.VAD.load(),
         stt=deepgram.STT(model="nova-3", language="multi"),

--- a/metrics/metrics_llm.py
+++ b/metrics/metrics_llm.py
@@ -68,8 +68,6 @@ class LLMMetricsAgent(Agent):
 
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/metrics/metrics_stt.py
+++ b/metrics/metrics_stt.py
@@ -96,8 +96,6 @@ class STTMetricsAgent(Agent):
 
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/metrics/metrics_tts.py
+++ b/metrics/metrics_tts.py
@@ -69,8 +69,6 @@ class TTSMetricsAgent(Agent):
 
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/metrics/metrics_vad.py
+++ b/metrics/metrics_vad.py
@@ -64,8 +64,6 @@ class VADMetricsAgent(Agent):
 
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/metrics/send-metrics-to-3p/send_metrics_to_3p.py
+++ b/metrics/send-metrics-to-3p/send_metrics_to_3p.py
@@ -173,8 +173,6 @@ class CombinedMetricsAgent(Agent):
 
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/multi-agent/long_or_short_agent.py
+++ b/multi-agent/long_or_short_agent.py
@@ -59,8 +59,6 @@ class LongAgent(Agent):
         self.session.update_agent(ShortAgent())
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-llm/anthropic_llm.py
+++ b/pipeline-llm/anthropic_llm.py
@@ -26,8 +26,6 @@ class SimpleAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-llm/cerebras_llm.py
+++ b/pipeline-llm/cerebras_llm.py
@@ -26,8 +26,6 @@ class SimpleAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-llm/google_llm.py
+++ b/pipeline-llm/google_llm.py
@@ -26,8 +26,6 @@ class SimpleAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-llm/interrupt_user.py
+++ b/pipeline-llm/interrupt_user.py
@@ -26,8 +26,6 @@ def count_sentences(text):
     return len(sentences)
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-    
     session = AgentSession()
     agent = Agent(
         instructions="You are a helpful agent that politely interrupts users when they talk too much.",

--- a/pipeline-llm/large_context.py
+++ b/pipeline-llm/large_context.py
@@ -39,8 +39,6 @@ class WarAndPeaceAgent(Agent):
         self.session.generate_reply("Welcome to the War and Peace book club! I'm here to discuss Leo Tolstoy's epic novel with you. What would you like to talk about?")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-llm/llm_powered_content_filter.py
+++ b/pipeline-llm/llm_powered_content_filter.py
@@ -108,7 +108,6 @@ class SimpleAgent(Agent):
         return process_stream()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
     await AgentSession().start(agent=SimpleAgent(), room=ctx.room)
 
 if __name__ == "__main__":

--- a/pipeline-llm/ollama_llm.py
+++ b/pipeline-llm/ollama_llm.py
@@ -26,8 +26,6 @@ class SimpleAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-llm/openai_llm.py
+++ b/pipeline-llm/openai_llm.py
@@ -26,8 +26,6 @@ class SimpleAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-llm/replacing_llm_output.py
+++ b/pipeline-llm/replacing_llm_output.py
@@ -56,8 +56,6 @@ class SimpleAgent(Agent):
         return process_stream()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-llm/simple_content_filter.py
+++ b/pipeline-llm/simple_content_filter.py
@@ -49,8 +49,6 @@ class SimpleAgent(Agent):
         return process_stream()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-llm/transcription_node.py
+++ b/pipeline-llm/transcription_node.py
@@ -54,8 +54,6 @@ class SimpleAgent(Agent):
         return process_text()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-stt/diarization.py
+++ b/pipeline-stt/diarization.py
@@ -111,8 +111,6 @@ class DiarizationAgent(Agent):
         await self.session.say(f"Hi there! Is there anything I can help you with?")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     userdata = SpeechmaticsUserData(ctx=ctx)
 
     session = AgentSession[SpeechmaticsUserData](

--- a/pipeline-stt/keyword_detection.py
+++ b/pipeline-stt/keyword_detection.py
@@ -48,8 +48,6 @@ class SimpleAgent(Agent):
         return process_stream()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-stt/transcriber.py
+++ b/pipeline-stt/transcriber.py
@@ -10,8 +10,6 @@ import datetime
 load_dotenv(dotenv_path=Path(__file__).parent.parent / '.env')
 
 async def entrypoint(ctx: JobContext):
-    
-    await ctx.connect()
     session = AgentSession()
     
     @session.on("user_input_transcribed")

--- a/pipeline-tts/cartesia_tts.py
+++ b/pipeline-tts/cartesia_tts.py
@@ -30,8 +30,6 @@ class CartesiaAgent(Agent):
         await self.session.say(f"Hi there! Is there anything I can help you with?")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-tts/elevenlabs_change_language.py
+++ b/pipeline-tts/elevenlabs_change_language.py
@@ -103,8 +103,6 @@ class LanguageSwitcherAgent(Agent):
 
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-tts/elevenlabs_tts.py
+++ b/pipeline-tts/elevenlabs_tts.py
@@ -26,8 +26,6 @@ class ElevenLabsAgent(Agent):
         await self.session.say(f"Hi there! Is there anything I can help you with?")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-tts/only_greet.py
+++ b/pipeline-tts/only_greet.py
@@ -20,8 +20,6 @@ class GreeterAgent(Agent):
         self.session.say("Hi there! Is there anything I can help you with?")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-tts/openai_tts.py
+++ b/pipeline-tts/openai_tts.py
@@ -23,8 +23,6 @@ class SimpleAgent(Agent):
         await self.session.say(f"Hi there! Is there anything I can help you with?")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-tts/playai_tts.py
+++ b/pipeline-tts/playai_tts.py
@@ -27,8 +27,6 @@ class PlayAIAgent(Agent):
         await self.session.say(f"Hi there! Is there anything I can help you with?")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-tts/rime_tts.py
+++ b/pipeline-tts/rime_tts.py
@@ -27,8 +27,6 @@ class RimeAgent(Agent):
         await self.session.say(f"Hi there! Is there anything I can help you with?")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-tts/short_replies_only.py
+++ b/pipeline-tts/short_replies_only.py
@@ -48,8 +48,6 @@ class ShortRepliesOnlyAgent(Agent):
         await self.session.say(f"Hi there! Is there anything I can help you with?")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-tts/tts_comparison.py
+++ b/pipeline-tts/tts_comparison.py
@@ -169,8 +169,6 @@ class PlayAIAgent(Agent):
 
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/pipeline-tts/tts_node.py
+++ b/pipeline-tts/tts_node.py
@@ -44,8 +44,6 @@ class TtsNodeOverrideAgent(Agent):
         await self.session.say(f"Hi there! Is there anything I can help you with? If you say something funny, I might respond with lol.")
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/rag/main.py
+++ b/rag/main.py
@@ -216,8 +216,6 @@ class RAGEnrichedAgent(Agent):
 
 async def entrypoint(ctx: JobContext):
     """Main entrypoint for the agent."""
-    await ctx.connect()
-
     session = AgentSession(
         stt=deepgram.STT(),
         llm=openai.LLM(model="gpt-4o"),

--- a/realtime/openai-realtime-drive-thru.py
+++ b/realtime/openai-realtime-drive-thru.py
@@ -459,8 +459,6 @@ IMPORTANT: Always use the appropriate tools to manage the order. Don't just talk
 
 
 async def entrypoint(ctx: agents.JobContext):
-    await ctx.connect()
-
     session = AgentSession[DriveThruUserData](
         userdata=DriveThruUserData(),
         llm=openai.realtime.RealtimeModel(

--- a/realtime/openai-realtime-pitch-shift.py
+++ b/realtime/openai-realtime-pitch-shift.py
@@ -59,8 +59,6 @@ class Assistant(Agent):
         )
 
 async def entrypoint(ctx: agents.JobContext):
-    await ctx.connect()
-
     session = AgentSession(
         llm=openai.realtime.RealtimeModel(),
         vad=silero.VAD.load()

--- a/realtime/openai-realtime-tools.py
+++ b/realtime/openai-realtime-tools.py
@@ -345,8 +345,6 @@ class Assistant(Agent):
         return str((fahrenheit - 32) * 5 / 9)
 
 async def entrypoint(ctx: agents.JobContext):
-    await ctx.connect()
-
     session = AgentSession(
         llm=openai.realtime.RealtimeModel(
             model="gpt-4o-realtime-preview-2025-06-03"

--- a/realtime/openai-realtime.py
+++ b/realtime/openai-realtime.py
@@ -14,8 +14,6 @@ class Assistant(Agent):
         super().__init__(instructions="You are a helpful voice AI assistant.")
 
 async def entrypoint(ctx: agents.JobContext):
-    await ctx.connect()
-
     session = AgentSession(
         llm=openai.realtime.RealtimeModel(),
         vad=silero.VAD.load()

--- a/rpc/rpc_agent.py
+++ b/rpc/rpc_agent.py
@@ -230,8 +230,6 @@ class RPCStateAgent(Agent):
 
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     # Create user session data - this is the shared state container
     userdata = UserSessionData()
     

--- a/telephony/answer_call.py
+++ b/telephony/answer_call.py
@@ -24,8 +24,6 @@ class SimpleAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
     agent = SimpleAgent()
 

--- a/telephony/make_call/calling_agent.py
+++ b/telephony/make_call/calling_agent.py
@@ -30,8 +30,6 @@ class SimpleAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/telephony/sip_lifecycle.py
+++ b/telephony/sip_lifecycle.py
@@ -145,8 +145,6 @@ class SIPLifecycleAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-    
     session = AgentSession()
     agent = SIPLifecycleAgent(job_context=ctx)
 

--- a/telephony/survey_caller/survey_calling_agent.py
+++ b/telephony/survey_caller/survey_calling_agent.py
@@ -70,8 +70,6 @@ class SurveyAgent(Agent):
         return None, f"[Call ended]"
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-    
     metadata_json = ctx.job.metadata
     logger.info(f"Received metadata: {metadata_json}")
     

--- a/telephony/warm_handoff.py
+++ b/telephony/warm_handoff.py
@@ -104,8 +104,6 @@ class WarmHandoffAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
     agent = WarmHandoffAgent(job_context=ctx)
 

--- a/tool_calling/call_function_tool.py
+++ b/tool_calling/call_function_tool.py
@@ -36,8 +36,6 @@ class FunctionAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/tool_calling/update_tools.py
+++ b/tool_calling/update_tools.py
@@ -37,8 +37,6 @@ class AddFunctionAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
     agent=AddFunctionAgent()
 

--- a/tracking_state/npc_character.py
+++ b/tracking_state/npc_character.py
@@ -162,7 +162,6 @@ class NPCSummaryAgent(BaseAgent):
             logger.error(f"Error deleting room: {e}")
 
 async def entrypoint(ctx: JobContext) -> None:
-    await ctx.connect()
     session = AgentSession[NPCData]()
     session.userdata = NPCData()
     await session.start(

--- a/translators/pipeline_translator.py
+++ b/translators/pipeline_translator.py
@@ -31,8 +31,6 @@ class SimpleAgent(Agent):
         self.session.generate_reply()
 
 async def entrypoint(ctx: JobContext):
-    await ctx.connect()
-
     session = AgentSession()
 
     await session.start(

--- a/translators/tts_translator.py
+++ b/translators/tts_translator.py
@@ -12,8 +12,6 @@ from launch_demos.livekit_plugins_gladia import stt
 load_dotenv(dotenv_path=Path(__file__).parent.parent / '.env')
 
 async def entrypoint(ctx: JobContext):
-    
-    await ctx.connect()
     session = AgentSession()
     
     # Process transcription events - let the agent say what it receives


### PR DESCRIPTION
Explicitly calling ctx.connect() is not needed after 1.1.0 - https://github.com/livekit/agents/pull/2505

Updating examples accordingly.