### PR TITLE
explicitly calling ctx.connect when connection is needed

### DIFF
--- a/avatars/tavus/tavus.py
+++ b/avatars/tavus/tavus.py
@@ -405,6 +405,8 @@ class AvatarAgent(Agent):
 
 async def entrypoint(ctx: JobContext):
     agent = AvatarAgent()
+    await ctx.connect()
+    
     # Create a single AgentSession with userdata
     userdata = UserData(ctx=ctx)
     session = AgentSession[UserData](

--- a/complex-agents/ivr-agent/agent.py
+++ b/complex-agents/ivr-agent/agent.py
@@ -124,7 +124,7 @@ async def entrypoint(ctx: JobContext):
             )
         )
 
-    # Wait for the first participant to connect
+    # Wait for the first participant to connect after starting the agent session
     await ctx.wait_for_participant()
     logger.info("Waiting for SIP participants to connect")
 

--- a/complex-agents/ivr-agent/agent.py
+++ b/complex-agents/ivr-agent/agent.py
@@ -124,7 +124,7 @@ async def entrypoint(ctx: JobContext):
             )
         )
 
-    # Wait for the first participant to connect after starting the agent session
+    # Wait for the first participant to connect
     await ctx.wait_for_participant()
     logger.info("Waiting for SIP participants to connect")
 

--- a/complex-agents/nutrition-assistant/agent.py
+++ b/complex-agents/nutrition-assistant/agent.py
@@ -467,6 +467,13 @@ async def entrypoint(ctx: agents.JobContext):
     # Initialize database on startup
     init_database()
 
+    # Connect to the room *before* awaiting the participant
+    await ctx.connect()
+    
+    # Wait for participant
+    participant = await ctx.wait_for_participant()
+    print(f"Starting nutrition assistant for {participant.identity} (using fixed ID: {FIXED_PARTICIPANT_ID})")
+
     session = AgentSession[NutritionUserData](
         userdata=NutritionUserData(participant_identity=FIXED_PARTICIPANT_ID, ctx=ctx),
         llm=openai.realtime.RealtimeModel(
@@ -487,10 +494,6 @@ async def entrypoint(ctx: agents.JobContext):
             noise_cancellation=noise_cancellation.BVC()
         )
     )
-
-    # Wait for participant
-    participant = await ctx.wait_for_participant()
-    print(f"Starting nutrition assistant for {participant.identity} (using fixed ID: {FIXED_PARTICIPANT_ID})")
 
     await asyncio.sleep(0.5)
     

--- a/complex-agents/nutrition-assistant/agent.py
+++ b/complex-agents/nutrition-assistant/agent.py
@@ -466,9 +466,6 @@ async def send_initial_nutrition_update(ctx: agents.JobContext, participant_iden
 async def entrypoint(ctx: agents.JobContext):
     # Initialize database on startup
     init_database()
-    # Wait for participant
-    participant = await ctx.wait_for_participant()
-    print(f"Starting nutrition assistant for {participant.identity} (using fixed ID: {FIXED_PARTICIPANT_ID})")
 
     session = AgentSession[NutritionUserData](
         userdata=NutritionUserData(participant_identity=FIXED_PARTICIPANT_ID, ctx=ctx),
@@ -490,6 +487,10 @@ async def entrypoint(ctx: agents.JobContext):
             noise_cancellation=noise_cancellation.BVC()
         )
     )
+
+    # Wait for participant
+    participant = await ctx.wait_for_participant()
+    print(f"Starting nutrition assistant for {participant.identity} (using fixed ID: {FIXED_PARTICIPANT_ID})")
 
     await asyncio.sleep(0.5)
     

--- a/complex-agents/role-playing/agent.py
+++ b/complex-agents/role-playing/agent.py
@@ -17,6 +17,7 @@ load_dotenv()
 
 async def entrypoint(ctx: JobContext):
     """Main entry point for the game"""
+    await ctx.connect()
     # Initialize user data
     userdata = GameUserData(ctx=ctx)
     

--- a/rpc/rpc_agent.py
+++ b/rpc/rpc_agent.py
@@ -230,6 +230,9 @@ class RPCStateAgent(Agent):
 
 
 async def entrypoint(ctx: JobContext):
+    # Connect to the room *before* awaiting the participant
+    await ctx.connect()
+
     # Create user session data - this is the shared state container
     userdata = UserSessionData()
     

--- a/rpc/rpc_agent.py
+++ b/rpc/rpc_agent.py
@@ -257,7 +257,7 @@ async def entrypoint(ctx: JobContext):
     # So changes made via RPC are visible to the LLM, and changes made by
     # the LLM are visible via RPC.
 
-    # Wait for a participant to join after starting the agent session
+    # Wait for a participant to join before proceeding
     participant = await ctx.wait_for_participant()
     logger.info(f"Participant {participant.identity} joined")
 

--- a/rpc/rpc_agent.py
+++ b/rpc/rpc_agent.py
@@ -254,10 +254,6 @@ async def entrypoint(ctx: JobContext):
     # So changes made via RPC are visible to the LLM, and changes made by
     # the LLM are visible via RPC.
 
-    # Wait for a participant to join before proceeding
-    participant = await ctx.wait_for_participant()
-    logger.info(f"Participant {participant.identity} joined")
-
     # ====== RPC Handler for Client State Operations ======
     """
     RPC handler for managing state operations through RPC calls.
@@ -427,6 +423,10 @@ async def entrypoint(ctx: JobContext):
             audio_enabled=True
         )
     )
+
+    # Wait for a participant to join after starting the agent session
+    participant = await ctx.wait_for_participant()
+    logger.info(f"Participant {participant.identity} joined")
 
 if __name__ == "__main__":
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))

--- a/rpc/rpc_agent.py
+++ b/rpc/rpc_agent.py
@@ -257,6 +257,10 @@ async def entrypoint(ctx: JobContext):
     # So changes made via RPC are visible to the LLM, and changes made by
     # the LLM are visible via RPC.
 
+    # Wait for a participant to join after starting the agent session
+    participant = await ctx.wait_for_participant()
+    logger.info(f"Participant {participant.identity} joined")
+
     # ====== RPC Handler for Client State Operations ======
     """
     RPC handler for managing state operations through RPC calls.
@@ -426,10 +430,6 @@ async def entrypoint(ctx: JobContext):
             audio_enabled=True
         )
     )
-
-    # Wait for a participant to join after starting the agent session
-    participant = await ctx.wait_for_participant()
-    logger.info(f"Participant {participant.identity} joined")
 
 if __name__ == "__main__":
     cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))


### PR DESCRIPTION
Since ctx.wait_for_participant depends on room to be connected, explicitly calling ctx.connect() in the cases when it's needed.

Solves for issue: https://github.com/livekit-examples/python-agents-examples/issues/36