### PR TITLE
Add Moondream vision example

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ websockets>=11.0.3
 rich
 mcp
 librosa
+moondream

--- a/vision/moondream_vision.py
+++ b/vision/moondream_vision.py
@@ -1,0 +1,126 @@
+"""
+---
+title: Moondream Vision Agent
+category: vision
+tags: [moondream, vision]
+difficulty: intermediate
+description: Moondream Vision Agent
+demonstrates:
+  - Adding vision capabilities to an agent when the LLM does not have vision capabilities
+---
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from dotenv import load_dotenv
+from PIL import Image
+import moondream as md
+import os
+from datetime import datetime
+from livekit import rtc
+from livekit.rtc._proto import video_frame_pb2 as proto_video
+from livekit.agents import JobContext, WorkerOptions, cli, get_job_context
+from livekit.agents.llm import function_tool, ImageContent, ChatContext, ChatMessage
+from livekit.agents.voice import Agent, AgentSession, RunContext
+from livekit.plugins import deepgram, openai, silero, rime
+
+logger = logging.getLogger("vision-agent")
+logger.setLevel(logging.INFO)
+
+load_dotenv(dotenv_path=Path(__file__).parent.parent / '.env')
+
+class VisionAgent(Agent):
+    def __init__(self) -> None:
+        self._latest_frame = None
+        self._video_stream = None
+        self._tasks = []
+        # Create output directory for saved frames
+        self._output_dir = Path(__file__).parent / "saved_frames"
+        self._output_dir.mkdir(exist_ok=True)
+        self._md_model = md.vl(api_key=os.getenv("MOONDREAM_API_KEY"))
+        super().__init__(
+            instructions="""
+                You are an assistant communicating through voice with vision capabilities.
+                You will be given a description of an image, and you can talk to the user about the images that are being shown.
+            """,
+            stt=deepgram.STT(),
+            llm=openai.LLM(),
+            tts=rime.TTS(),
+            vad=silero.VAD.load()
+        )
+
+    async def on_enter(self):
+        room = get_job_context().room
+
+        # Find the first video track (if any) from the remote participant
+        if room.remote_participants:
+            remote_participant = list(room.remote_participants.values())[0]
+            video_tracks = [
+                publication.track
+                for publication in list(remote_participant.track_publications.values())
+                if publication.track and publication.track.kind == rtc.TrackKind.KIND_VIDEO
+            ]
+            if video_tracks:
+                self._create_video_stream(video_tracks[0])
+
+        # Watch for new video tracks not yet published
+        @room.on("track_subscribed")
+        def on_track_subscribed(track: rtc.Track, publication: rtc.RemoteTrackPublication, participant: rtc.RemoteParticipant):
+            if track.kind == rtc.TrackKind.KIND_VIDEO:
+                self._create_video_stream(track)
+
+    def _send_frame_to_moondream(self, frame: rtc.VideoFrame) -> str | None:
+        try:
+            rgb_frame = frame.convert(proto_video.VideoBufferType.RGB24)
+            image = Image.frombytes(
+                "RGB",
+                (rgb_frame.width, rgb_frame.height),
+                rgb_frame.data.tobytes(),
+            )
+            caption = self._md_model.caption(image).get("caption")
+            if caption:
+                logger.info("Moondream caption: %s", caption)
+            return caption
+        except Exception as exc:
+            logger.error("Error sending frame to Moondream: %s", exc)
+            return None
+
+    async def on_user_turn_completed(self, turn_ctx: ChatContext, new_message: ChatMessage) -> None:
+        # Add the latest video frame, if any, to the new message
+        if self._latest_frame:
+            # Send the frame to Moondream
+            caption = self._send_frame_to_moondream(self._latest_frame)
+            if caption:
+                # Add the image description as text content to the message
+                new_message.content.append(f"[Image description: {caption}]")
+            self._latest_frame = None
+
+    # Helper method to buffer the latest video frame from the user's track
+    def _create_video_stream(self, track: rtc.Track):
+        # Close any existing stream (we only want one at a time)
+        if self._video_stream is not None:
+            self._video_stream.close()
+
+        # Create a new stream to receive frames
+        self._video_stream = rtc.VideoStream(track)
+        async def read_stream():
+            async for event in self._video_stream:
+                # Store the latest frame for use later
+                self._latest_frame = event.frame
+
+        # Store the async task
+        task = asyncio.create_task(read_stream())
+        task.add_done_callback(lambda t: self._tasks.remove(t))
+        self._tasks.append(task)
+
+async def entrypoint(ctx: JobContext):
+    session = AgentSession()
+
+    await session.start(
+        agent=VisionAgent(),
+        room=ctx.room
+    )
+
+if __name__ == "__main__":
+    cli.run_app(WorkerOptions(entrypoint_fnc=entrypoint))

--- a/vision/moondream_vision.py
+++ b/vision/moondream_vision.py
@@ -17,7 +17,6 @@ from dotenv import load_dotenv
 from PIL import Image
 import moondream as md
 import os
-from datetime import datetime
 from livekit import rtc
 from livekit.rtc._proto import video_frame_pb2 as proto_video
 from livekit.agents import JobContext, WorkerOptions, cli, get_job_context
@@ -35,9 +34,6 @@ class VisionAgent(Agent):
         self._latest_frame = None
         self._video_stream = None
         self._tasks = []
-        # Create output directory for saved frames
-        self._output_dir = Path(__file__).parent / "saved_frames"
-        self._output_dir.mkdir(exist_ok=True)
         self._md_model = md.vl(api_key=os.getenv("MOONDREAM_API_KEY"))
         super().__init__(
             instructions="""


### PR DESCRIPTION
This pull request introduces a new `Moondream Vision Agent` in the `vision/moondream_vision.py` file. The agent adds vision capabilities to a voice-based assistant by integrating the Moondream API for image captioning. The main changes include the creation of the `VisionAgent` class, which processes video frames from a remote participant, generates captions for those frames, and incorporates the captions into the agent's responses.

Key additions and features:

**Vision Agent Implementation:**

* Added the `VisionAgent` class, which extends the `Agent` class to support vision capabilities by processing video frames and generating image captions using the Moondream API.
* Integrated logic to subscribe to remote video tracks, buffer the latest frame, and send it to Moondream for captioning.
* Enhanced the agent's response flow to include image descriptions in the conversation when a video frame is available.