### PR TITLE
Fix scrolling in model-battleground app layout

### DIFF
--- a/complex-agents/model-battleground/frontend/components/app/app.tsx
+++ b/complex-agents/model-battleground/frontend/components/app/app.tsx
@@ -13,7 +13,7 @@ interface AppProps {
 export function App({ appConfig }: AppProps) {
   return (
     <SessionProvider appConfig={appConfig}>
-      <main className="h-svh w-full overflow-hidden">
+      <main className="min-h-svh w-full overflow-y-auto">
         <ViewController />
       </main>
       <StartAudio label="Start Audio" />


### PR DESCRIPTION
  ## Summary
                                                                                
 Fix scrolling on the model-battleground app layout. On small screens, the "Start call" button was hidden below the viewport because the main container used h-svh with overflow-hidden, preventing users from scrolling to reach it.

  ## Changes

  - Changed h-svh overflow-hidden to min-h-svh overflow-y-auto on the main container, allowing vertical scrolling when content exceeds the viewport height.