### PR TITLE
Stop the front desk repeating its acknowledgements

### DIFF
--- a/complex-agents/xai-patient-intake/patient-intake-agent/src/prompts/expressive.md
+++ b/complex-agents/xai-patient-intake/patient-intake-agent/src/prompts/expressive.md
@@ -3,3 +3,5 @@
 Everything above shapes how a line sounds. None of it does anything.
 
 Booking, moving, cancelling, recording, updating, and passing a request to a person still happen only through a tool. So before you say that something is booked, moved, cancelled, recorded, sent, or all set, call the tool that does it in this same turn. A beautifully delivered "you're all set" over a chart where nothing happened is the worst thing you can say on this call.
+
+Never open two turns in a row with the same acknowledgement or confirmation, diversify your responses to ensure a natural conversation rather than a repetitive mechanical one. 

--- a/complex-agents/xai-patient-intake/patient-intake-agent/src/prompts/reception.md
+++ b/complex-agents/xai-patient-intake/patient-intake-agent/src/prompts/reception.md
@@ -15,8 +15,7 @@ If someone says they have never been here, are not a patient, or want a first vi
 they are a new patient. Their request for an appointment is already a request to get
 them set up. Ask for the patient's full name and date of birth naturally, then continue.
 Never ask whether they want to become a patient, register, or have a chart. Never tell
-them that no existing chart was found. A natural next line is simply: "Of course. What's
-your full name and date of birth?"
+them that no existing chart was found.
 
 For established-patient work, ask for the patient's last name and full date of birth.
 If a tool says they do not match, ask the caller to check those details. Do not guess.


### PR DESCRIPTION
On a console call, the agent opened two consecutive turns with "Of course." — once into *"have you been seen here before, or would this be a new patient visit?"*, then again into *"what's your full name and date of birth?"*. Two turns in, the caller is talking to a script.

Two halves to the fix:

**`reception.md`** suggested one of those lines verbatim — `A natural next line is simply: "Of course. What's your full name and date of birth?"` — which is where the second "Of course." came from. The surrounding paragraph already states what the turn has to accomplish (ask for full name and date of birth naturally, never ask whether they want to register), so the example was only seeding a stock phrase.

**`expressive.md`** now states the rule directly. It sits well next to the base xAI template, which already carries the same rule for non-verbal sounds — *"never the same one twice in a row — reach for one only where it genuinely fits. An enabled sound gets over-used otherwise."* This file reaches the model through `tts_instructions_append`, so it lands after that template.

Deployed to demo-agents as `Y6audAqmA3av` to hear it on a live call.

Prompt-only; no code, model, or config changes. The model remains `xai/grok-4.3` with `reasoning_effort: "none"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)