### PR TITLE
Refine the xAI patient intake frontend: model tooltip and spoken openers

### DIFF
--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/AgentCards.tsx
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/AgentCards.tsx
@@ -10,6 +10,7 @@ import { motion } from 'motion/react';
 import { agentAccentStyle } from '@/app/(showcase)/_components/agent-themes';
 import { AgentAudioVisualizerGrid } from '@/components/voice-agent/agent-audio-visualizer-grid';
 import { slugFromAgentName, type AgentMetadata } from './agent-metadata';
+import { ModelBadge } from './ModelBadge';
 import { agentMorphName, MORPH_SPRING } from './utils';
 
 const CARD_BASE =
@@ -90,11 +91,7 @@ export function AgentCard({ agent, onSelect, justExitedAgentName }: AgentCardPro
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-2">
             <h2 className="text-fg0 text-xl font-semibold">{agent.title}</h2>
-            {agent.headlineModel && (
-              <Badge variant="muted" size="large">
-                {agent.headlineModel}
-              </Badge>
-            )}
+            <ModelBadge agent={agent} />
           </div>
           {agent.description && <p className="text-fg3 text-sm">{agent.description}</p>}
         </div>

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/AgentConversation.tsx
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/AgentConversation.tsx
@@ -3,12 +3,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { SiGithub } from '@icons-pack/react-simple-icons';
-import { ArrowLeftIcon, Badge, Button, IconButton } from '@/components/bytes';
+import { ArrowLeftIcon, Button, IconButton } from '@/components/bytes';
 import { motion } from 'motion/react';
 
 import { agentAccentStyle } from '@/app/(showcase)/_components/agent-themes';
 import { AgentControlBar } from '@/components/agents-ui/agent-control-bar';
 import { type AgentMetadata } from './agent-metadata';
+import { ModelBadge } from './ModelBadge';
 import { AgentSession } from './AgentSession';
 import { AgentTranscript } from './transcript/AgentTranscript';
 import { MORPH_SPRING } from './utils';
@@ -93,11 +94,7 @@ export function AgentConversation({
               <ArrowLeftIcon />
             </IconButton>
             <h2 className="text-fg0 truncate text-lg font-semibold">{agent.title}</h2>
-            {agent.headlineModel && (
-              <Badge variant="muted" size="large" className="shrink-0 tracking-wider">
-                {agent.headlineModel.toUpperCase()}
-              </Badge>
-            )}
+            <ModelBadge agent={agent} />
           </div>
           {agent.repoUrl && (
             <Button variant="ghost" className="shrink-0" asChild>
@@ -110,7 +107,11 @@ export function AgentConversation({
         </div>
         <div className="flex min-h-0 flex-1 flex-col gap-8 pt-6 pb-8">
           <AgentSession agentName={agent.name} onLeave={handleLeave}>
-            <AgentTranscript className="min-h-0 w-full flex-1" agentName={agent.name} />
+            <AgentTranscript
+              className="min-h-0 w-full flex-1"
+              agentName={agent.name}
+              starters={agent.starters}
+            />
             <div className="flex flex-col items-center justify-center gap-4">
               <AgentControlBar
                 variant="livekit"

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/AgentShowcase.tsx
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/AgentShowcase.tsx
@@ -2,9 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import Link from 'next/link';
-import { SiGithub } from '@icons-pack/react-simple-icons';
-import { Button, cn } from '@/components/bytes';
+import { cn } from '@/components/bytes';
 import { AnimatePresence } from 'motion/react';
 
 import { AGENTS, resolveActiveAgent } from './agent-metadata';
@@ -101,16 +99,6 @@ export function AgentShowcase() {
                 </div>
               ))}
             </div>
-            <Button variant="outline" size="sm" asChild>
-              <Link
-                href="https://github.com/livekit/agents"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <SiGithub className="size-4" />
-                View on GitHub
-              </Link>
-            </Button>
           </div>
         )}
       </AnimatePresence>

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/ModelBadge.tsx
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/ModelBadge.tsx
@@ -52,9 +52,9 @@ export function ModelBadge({ agent }: ModelBadgeProps) {
         </TooltipPrimitive.Trigger>
         <TooltipPrimitive.Portal>
           <TooltipPrimitive.Content
-            side="bottom"
-            align="start"
-            sideOffset={6}
+            side="right"
+            align="center"
+            sideOffset={8}
             collisionPadding={12}
             className="border-separator1 bg-bg2 text-fg1 animate-in fade-in-0 zoom-in-95 z-50 rounded-md border px-3 py-2 shadow-lg"
           >

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/ModelBadge.tsx
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/ModelBadge.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Tooltip as TooltipPrimitive } from 'radix-ui';
+
+import type { AgentMetadata } from '@/app/(showcase)/_components/agent-metadata';
+import { Badge } from '@/components/bytes';
+
+interface ModelBadgeProps {
+  agent: AgentMetadata;
+}
+
+/**
+ * The headline badge, with the cascade behind it on hover.
+ *
+ * The badge names the family rather than one model ("Grok Voice Models"), because three
+ * models are doing the work and picking one of them to print was always a half-truth. The
+ * tooltip carries the rest: which model runs each stage of the pipeline.
+ *
+ * `Badge` is `pointer-events-none` (vendored that way from bytes-react), so the trigger has
+ * to be the span around it rather than the badge itself.
+ */
+export function ModelBadge({ agent }: ModelBadgeProps) {
+  if (!agent.headlineModel) {
+    return null;
+  }
+
+  // No .toUpperCase() here: `text-mono-caps` in the badge already uppercases, and the
+  // header used to do both.
+  const label = agent.headlineModel;
+
+  if (agent.models.length === 0) {
+    return (
+      <Badge variant="muted" size="large" className="shrink-0 tracking-wider">
+        {label}
+      </Badge>
+    );
+  }
+
+  return (
+    <TooltipPrimitive.Provider delayDuration={150}>
+      <TooltipPrimitive.Root>
+        <TooltipPrimitive.Trigger asChild>
+          <span className="shrink-0 cursor-help outline-none" tabIndex={0}>
+            <Badge
+              variant="muted"
+              size="large"
+              className="tracking-wider underline decoration-dotted underline-offset-4"
+            >
+              {label}
+            </Badge>
+          </span>
+        </TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            side="bottom"
+            align="start"
+            sideOffset={6}
+            collisionPadding={12}
+            className="border-separator1 bg-bg2 text-fg1 animate-in fade-in-0 zoom-in-95 z-50 rounded-md border px-3 py-2 shadow-lg"
+          >
+            <p className="text-fg3 text-xxs mb-1.5 font-semibold tracking-wider uppercase">
+              Cascaded pipeline
+            </p>
+            <dl className="grid grid-cols-[auto_auto] gap-x-4 gap-y-1 text-xs">
+              {agent.models.map((model) => (
+                <div key={model.role} className="contents">
+                  <dt className="text-fg3">{model.role}</dt>
+                  <dd className="text-fg1 font-mono">{model.name}</dd>
+                </div>
+              ))}
+            </dl>
+            <TooltipPrimitive.Arrow className="fill-bg2" />
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
+    </TooltipPrimitive.Provider>
+  );
+}

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/agent-metadata.ts
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/agent-metadata.ts
@@ -52,8 +52,8 @@ export const AGENTS: AgentMetadata[] = [
     ],
     starters: [
       'Can I book an appointment?',
-      'I need a refill on my prescription',
-      'I need to move my appointment',
+      'I need a refill on my prescription.',
+      'I need to move my appointment.',
     ],
     repoUrl:
       'https://github.com/livekit-examples/python-agents-examples/tree/main/complex-agents/xai-patient-intake',

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/agent-metadata.ts
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/agent-metadata.ts
@@ -50,7 +50,11 @@ export const AGENTS: AgentMetadata[] = [
       { role: 'Reasoning', name: 'xai/grok-4.3' },
       { role: 'Text to speech', name: 'xai/tts-1' },
     ],
-    starters: ['Book an appointment', 'Request a refill', 'Reschedule a visit'],
+    starters: [
+      'Can I book an appointment?',
+      'I need a refill on my prescription',
+      'I need to move my appointment',
+    ],
     repoUrl:
       'https://github.com/livekit-examples/python-agents-examples/tree/main/complex-agents/xai-patient-intake',
     comingSoon: false,

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/agent-metadata.ts
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/agent-metadata.ts
@@ -53,7 +53,7 @@ export const AGENTS: AgentMetadata[] = [
     starters: [
       'Can I book an appointment?',
       'I need a refill on my prescription.',
-      'I need to move my appointment.',
+      "I'd like to reschedule my visit.",
     ],
     repoUrl:
       'https://github.com/livekit-examples/python-agents-examples/tree/main/complex-agents/xai-patient-intake',

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/agent-metadata.ts
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/agent-metadata.ts
@@ -1,9 +1,20 @@
+export interface ModelStage {
+  /** Stage of the pipeline, e.g. "Speech to text". */
+  role: string;
+  /** Model id serving that stage. */
+  name: string;
+}
+
 export interface AgentMetadata {
   name: string;
   title: string;
   description: string;
+  /** Badge text. Names the family, not one model; the cascade lives in `models`. */
   headlineModel?: string;
-  models: string[];
+  /** One entry per pipeline stage, shown in the headline badge's tooltip. */
+  models: ModelStage[];
+  /** Openers offered once the agent has spoken, until the caller says something. */
+  starters?: { label: string; value: string }[];
   repoUrl?: string;
   comingSoon: boolean;
 }
@@ -33,8 +44,17 @@ export const AGENTS: AgentMetadata[] = [
     title: 'Patient Intake',
     description:
       'A family-medicine front-desk agent. Identifies callers against a chart, books and moves appointments, collects pre-visit clinical intake, and triages red-flag symptoms to emergency care',
-    headlineModel: 'Grok 4.3',
-    models: ['xAI Speech to Text', 'Grok 4.3', 'xAI Text to Speech'],
+    headlineModel: 'Grok Voice Models',
+    models: [
+      { role: 'Speech to text', name: 'xai/stt-1' },
+      { role: 'Reasoning', name: 'xai/grok-4.3' },
+      { role: 'Text to speech', name: 'xai/tts-1' },
+    ],
+    starters: [
+      { label: 'Book an appointment', value: "I'd like to book an appointment." },
+      { label: 'Request a refill', value: 'I need a refill on my prescription.' },
+      { label: 'Reschedule a visit', value: 'I need to move my appointment.' },
+    ],
     repoUrl:
       'https://github.com/livekit-examples/python-agents-examples/tree/main/complex-agents/xai-patient-intake',
     comingSoon: false,

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/agent-metadata.ts
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/agent-metadata.ts
@@ -13,8 +13,8 @@ export interface AgentMetadata {
   headlineModel?: string;
   /** One entry per pipeline stage, shown in the headline badge's tooltip. */
   models: ModelStage[];
-  /** Openers offered once the agent has spoken, until the caller says something. */
-  starters?: { label: string; value: string }[];
+  /** Openers to suggest aloud once the agent has spoken, until the caller says something. */
+  starters?: string[];
   repoUrl?: string;
   comingSoon: boolean;
 }
@@ -50,11 +50,7 @@ export const AGENTS: AgentMetadata[] = [
       { role: 'Reasoning', name: 'xai/grok-4.3' },
       { role: 'Text to speech', name: 'xai/tts-1' },
     ],
-    starters: [
-      { label: 'Book an appointment', value: "I'd like to book an appointment." },
-      { label: 'Request a refill', value: 'I need a refill on my prescription.' },
-      { label: 'Reschedule a visit', value: 'I need to move my appointment.' },
-    ],
+    starters: ['Book an appointment', 'Request a refill', 'Reschedule a visit'],
     repoUrl:
       'https://github.com/livekit-examples/python-agents-examples/tree/main/complex-agents/xai-patient-intake',
     comingSoon: false,

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/transcript/AgentTranscript.tsx
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/transcript/AgentTranscript.tsx
@@ -22,6 +22,7 @@ import { Shimmer } from '@/components/shimmer';
 import { MORPH_SPRING, getMoodColor } from '../utils';
 import { AgentTurn } from './AgentTurn';
 import { MiniVisualizer } from './MiniVisualizer';
+import { SpeakHints } from './SpeakHints';
 import { Suggestions } from './Suggestions';
 import { UserMessage } from './UserMessage';
 
@@ -56,8 +57,8 @@ interface AgentTranscriptProps {
   className?: string;
   /** Agent in this conversation, so an accent-themed one can opt out of the mood tint. */
   agentName?: string;
-  /** Openers to offer once the agent has spoken, until the caller says something. */
-  starters?: Suggestion[];
+  /** Openers to suggest aloud once the agent has spoken, until the caller says something. */
+  starters?: string[];
 }
 
 export function AgentTranscript({ className, agentName, starters }: AgentTranscriptProps) {
@@ -112,14 +113,15 @@ export function AgentTranscript({ className, agentName, starters }: AgentTranscr
     return { agentSpoke, callerSpoke };
   }, [transcriptionStreams, localIdentity]);
 
-  const showStarters =
+  const starterHints =
     agentSuggestions.length === 0 &&
-    (starters?.length ?? 0) > 0 &&
     spokenBy.agentSpoke &&
     !spokenBy.callerSpoke &&
-    sentMessages.length === 0;
-  const suggestions = agentSuggestions.length > 0 ? agentSuggestions : showStarters ? starters! : [];
-  const showSuggestions = !dismissed && suggestions.length > 0 && state === 'listening';
+    sentMessages.length === 0 &&
+    state === 'listening'
+      ? (starters ?? [])
+      : [];
+  const showSuggestions = !dismissed && agentSuggestions.length > 0 && state === 'listening';
 
   useEffect(() => {
     setDismissed(false);
@@ -306,8 +308,12 @@ export function AgentTranscript({ className, agentName, starters }: AgentTranscr
           </AnimatePresence>
 
           {showSuggestions && (
-            <Suggestions suggestions={suggestions} handleSuggestionClick={handleSuggestionClick} />
+            <Suggestions
+              suggestions={agentSuggestions}
+              handleSuggestionClick={handleSuggestionClick}
+            />
           )}
+          {starterHints.length > 0 && <SpeakHints hints={starterHints} />}
         </div>
       </div>
     </motion.div>

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/transcript/AgentTranscript.tsx
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/transcript/AgentTranscript.tsx
@@ -56,9 +56,11 @@ interface AgentTranscriptProps {
   className?: string;
   /** Agent in this conversation, so an accent-themed one can opt out of the mood tint. */
   agentName?: string;
+  /** Openers to offer once the agent has spoken, until the caller says something. */
+  starters?: Suggestion[];
 }
 
-export function AgentTranscript({ className, agentName }: AgentTranscriptProps) {
+export function AgentTranscript({ className, agentName, starters }: AgentTranscriptProps) {
   const { agent, state, audioTrack } = useVoiceAssistant();
   const { attributes } = useParticipantAttributes({ participant: agent });
   const room = useRoomContext();
@@ -84,10 +86,39 @@ export function AgentTranscript({ className, agentName }: AgentTranscriptProps) 
   }, [transcriptionStreams]);
 
   const rawSuggestions = attributes?.[AGENT_SUGGESTIONS_ATTRIBUTE];
-  const suggestions = useMemo(() => parseSuggestions(rawSuggestions), [rawSuggestions]);
+  const agentSuggestions = useMemo(() => parseSuggestions(rawSuggestions), [rawSuggestions]);
   const [dismissed, setDismissed] = useState(false);
   const [sentMessages, setSentMessages] = useState<{ id: string; ts: number; text: string }[]>([]);
   const sentCountRef = useRef(0);
+
+  // Starters are for the opening beat only: they appear once the agent has said its greeting
+  // and retire the moment the caller has said anything at all, since past that point the
+  // conversation has a subject and a generic "book an appointment" is noise. An agent that
+  // publishes its own suggestions always wins, being able to read the room.
+  const localIdentity = room?.localParticipant?.identity;
+  const spokenBy = useMemo(() => {
+    let agentSpoke = false;
+    let callerSpoke = false;
+    for (const stream of transcriptionStreams) {
+      if (!stream.text.trim()) {
+        continue;
+      }
+      if (stream.participantInfo.identity === localIdentity) {
+        callerSpoke = true;
+      } else {
+        agentSpoke = true;
+      }
+    }
+    return { agentSpoke, callerSpoke };
+  }, [transcriptionStreams, localIdentity]);
+
+  const showStarters =
+    agentSuggestions.length === 0 &&
+    (starters?.length ?? 0) > 0 &&
+    spokenBy.agentSpoke &&
+    !spokenBy.callerSpoke &&
+    sentMessages.length === 0;
+  const suggestions = agentSuggestions.length > 0 ? agentSuggestions : showStarters ? starters! : [];
   const showSuggestions = !dismissed && suggestions.length > 0 && state === 'listening';
 
   useEffect(() => {

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/transcript/SpeakHints.tsx
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/transcript/SpeakHints.tsx
@@ -1,5 +1,3 @@
-import { Badge } from '@/components/bytes';
-
 interface SpeakHintsProps {
   hints: string[];
 }
@@ -10,21 +8,24 @@ interface SpeakHintsProps {
  * Deliberately not buttons. A click would send the text straight to the agent and skip the
  * microphone, which is the one part of this demo worth showing; the hints exist to get
  * someone talking, not to give them a way around it.
+ *
+ * Shaped like the caller's own messages -- right-aligned, same pill, same type -- because
+ * that is exactly what they would become if spoken. They are dimmed and outlined rather
+ * than filled, so the column reads as "not said yet" instead of a transcript of things the
+ * caller already said.
  */
 export function SpeakHints({ hints }: SpeakHintsProps) {
   return (
-    <div className="animate-in fade-in-0 slide-in-from-bottom-2 flex flex-wrap items-center justify-end gap-2 pl-14 duration-300">
+    <div className="animate-in fade-in-0 slide-in-from-bottom-2 flex flex-col items-end gap-1.5 duration-300">
       <span className="text-fg3 text-xs">Try saying</span>
       {hints.map((hint, index) => (
-        <span
+        <p
           key={hint}
-          className="animate-in fade-in-0 inline-flex duration-300"
+          className="border-separator1 text-fg3 animate-in fade-in-0 rounded-2xl border border-dashed px-4 py-2 text-sm leading-relaxed duration-300 lg:ml-12"
           style={{ animationDelay: `${index * 120}ms`, animationFillMode: 'both' }}
         >
-          <Badge variant="muted" size="large">
-            {hint}
-          </Badge>
-        </span>
+          {hint}
+        </p>
       ))}
     </div>
   );

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/transcript/SpeakHints.tsx
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/transcript/SpeakHints.tsx
@@ -1,0 +1,31 @@
+import { Badge } from '@/components/bytes';
+
+interface SpeakHintsProps {
+  hints: string[];
+}
+
+/**
+ * Openers the caller can say, offered once the agent has greeted them.
+ *
+ * Deliberately not buttons. A click would send the text straight to the agent and skip the
+ * microphone, which is the one part of this demo worth showing; the hints exist to get
+ * someone talking, not to give them a way around it.
+ */
+export function SpeakHints({ hints }: SpeakHintsProps) {
+  return (
+    <div className="animate-in fade-in-0 slide-in-from-bottom-2 flex flex-wrap items-center justify-end gap-2 pl-14 duration-300">
+      <span className="text-fg3 text-xs">Try saying</span>
+      {hints.map((hint, index) => (
+        <span
+          key={hint}
+          className="animate-in fade-in-0 inline-flex duration-300"
+          style={{ animationDelay: `${index * 120}ms`, animationFillMode: 'both' }}
+        >
+          <Badge variant="muted" size="large">
+            {hint}
+          </Badge>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/transcript/SpeakHints.tsx
+++ b/complex-agents/xai-patient-intake/frontend/app/(showcase)/_components/transcript/SpeakHints.tsx
@@ -10,23 +10,29 @@ interface SpeakHintsProps {
  * someone talking, not to give them a way around it.
  *
  * Shaped like the caller's own messages -- right-aligned, same pill, same type -- because
- * that is exactly what they would become if spoken. They are dimmed and outlined rather
- * than filled, so the column reads as "not said yet" instead of a transcript of things the
- * caller already said.
+ * that is exactly what they would become if spoken. They are dimmed, italic and outlined
+ * rather than filled, so the column reads as "not said yet" instead of a transcript of
+ * things the caller already said. The italics are load-bearing: a dashed pill on its own
+ * still reads as a button, and these are not clickable.
  */
 export function SpeakHints({ hints }: SpeakHintsProps) {
   return (
     <div className="animate-in fade-in-0 slide-in-from-bottom-2 flex flex-col items-end gap-1.5 duration-300">
       <span className="text-fg3 text-xs">Try saying</span>
-      {hints.map((hint, index) => (
-        <p
-          key={hint}
-          className="border-separator1 text-fg3 animate-in fade-in-0 rounded-2xl border border-dashed px-4 py-2 text-sm leading-relaxed duration-300 lg:ml-12"
-          style={{ animationDelay: `${index * 120}ms`, animationFillMode: 'both' }}
-        >
-          {hint}
-        </p>
-      ))}
+      {/* Opacity sits on this wrapper, not the pills: `fade-in-0` ends on opacity 1 and
+          `animationFillMode: both` holds it there, so a class on the animated element
+          would be overridden the moment the animation finished. */}
+      <div className="flex flex-col items-end gap-1.5 opacity-70">
+        {hints.map((hint, index) => (
+          <p
+            key={hint}
+            className="border-separator1 text-fg3 animate-in fade-in-0 rounded-2xl border border-dashed px-4 py-2 text-sm italic leading-relaxed duration-300 lg:ml-12"
+            style={{ animationDelay: `${index * 120}ms`, animationFillMode: 'both' }}
+          >
+            {hint}
+          </p>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Three changes to the showcase page.

## The badge names the pipeline, not one model

It said "Grok 4.3", which picked one of three models and printed it as though it were the whole story. It now reads **Grok Voice Models**, and hovering opens the cascade behind it:

| Stage | Model |
| --- | --- |
| Speech to text | `xai/stt-1` |
| Reasoning | `xai/grok-4.3` |
| Text to speech | `xai/tts-1` |

That also gives the metadata's `models` field a job — nothing rendered it before, so it had drifted into display names ("xAI Speech to Text") rather than model ids.

The tooltip is Radix, matching `components/ui`, because the vendored bytes `Badge` had its own tooltip path deliberately stripped when it was copied in. `Badge` is `pointer-events-none`, so the hover target is the span around it. It opens to the right of the badge — anchored below, it landed squarely on the agent description, which is what someone is reading when they reach for the badge. The header's `.toUpperCase()` is gone too: `text-mono-caps` already uppercases, so the two were stacked.

## Openers after the greeting, as hints rather than buttons

The suggestion machinery was fully built on the frontend and never fed — nothing publishes `lk.agent.suggestions`, so the chips had nothing to render. Three openers now come from the showcase metadata and appear once the agent has spoken:

> Can I book an appointment? · I need a refill on my prescription. · I need to move my appointment.

They retire the moment the caller says anything, since past that point the conversation has a subject and a generic opener is noise.

**They are not clickable, on purpose.** A click sent the text on the chat topic, which reaches the agent without passing through the microphone — so the one control meant to get a visitor started was also the one that skipped speech recognition, the part of a voice demo worth showing. They are shaped like `UserMessage` — right-aligned, same pill, same type — because that is what each becomes if spoken, but dashed, italic and dimmed so the column reads as *not said yet*. The three phrases exercise three different tool paths: booking, `take_message`, and `manage_appointment`.

Suggestions published by the agent keep their click behaviour. An agent offering "Tuesday at one thirty" mid-call is offering a choice, not an opener, and a click is the right way to take it.

## "View on GitHub" removed

It pointed at `livekit/agents`, the SDK, from a page whose only subject is this one example. The card's own "Clone agent" button already goes to the example source, which is the link that was wanted.

---

`tsc --noEmit` and `next build` pass. The badge and tooltip are verified in a browser; the hints are typechecked and built but not yet seen in a live call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)